### PR TITLE
rotate linked list right by k places (hacktoberfest 2023)

### DIFF
--- a/Program's_Contributed_By_Contributors/Python_Programs/rotate_linked_list_right_by_k.py
+++ b/Program's_Contributed_By_Contributors/Python_Programs/rotate_linked_list_right_by_k.py
@@ -1,0 +1,91 @@
+
+class Node:
+    def __init__(self, data: int) -> None:
+        self.data = data
+        self.next = None
+
+
+def print_list(head: Node | None) -> None:
+    """
+    Prints the entire linked list iteratively
+    >>> head = insert_node(None, 1)
+    >>> head = insert_node(head, 2)
+    >>> head = insert_node(head, 3)
+    >>> print_list(head)
+    1->2->3
+    >>> head = insert_node(head, 4)
+    >>> head = insert_node(head, 5)
+    >>> print_list(head)
+    1->2->3->4->5
+    """
+    if head is not None:
+        while head.next is not None:
+            print(head.data, end="->")
+            head = head.next
+        print(head.data)
+
+
+def insert_node(head: Node | None, data: int) -> Node:
+    """
+    Returns new head of linked list after inserting new node
+    >>> head = insert_node(None, 1)
+    >>> head = insert_node(head, 2)
+    >>> head = insert_node(head, 3)
+    >>> print_list(head)
+    1->2->3
+    """
+    new_node = Node(data)
+    if head is None:
+        return new_node
+
+    temp_node = head
+    while temp_node.next is not None:
+        temp_node = temp_node.next
+    temp_node.next = new_node
+    return head
+
+
+def right_rotate_by_k(head: Node | None, k_places: int) -> Node | None:
+    """
+    This function receives head and k as input
+    parameters and returns head of linked list
+    after rotation to the right by k places
+    >>> head = insert_node(None, 1)
+    >>> head = insert_node(head, 2)
+    >>> head = insert_node(head, 3)
+    >>> head = insert_node(head, 4)
+    >>> head = insert_node(head, 5)
+    >>> k = 2
+    >>> new_head = right_rotate_by_k(head, k)
+    >>> print_list(new_head)
+    4->5->1->2->3
+    """
+    if head is None or head.next is None:
+        return head
+    for _ in range(k_places):
+        temp_node = head
+        while temp_node.next.next is not None:
+            temp_node = temp_node.next
+        end = temp_node.next
+        temp_node.next = None
+        end.next = head
+        head = end
+    return head
+
+
+if __name__ == "__main__":
+
+    head = insert_node(None, 1)
+    head = insert_node(head, 2)
+    head = insert_node(head, 3)
+    head = insert_node(head, 4)
+    head = insert_node(head, 5)
+
+    print("Original list: ", end="")
+    print_list(head)
+
+    k = 2
+    new_head = right_rotate_by_k(head, k)
+
+    print("After", k, "iterations: ", end="")
+    print_list(new_head)

--- a/contributors/contributorsList.js
+++ b/contributors/contributorsList.js
@@ -2050,6 +2050,11 @@ contributors = [
     id:422,
     fullname:"Evgeny Skorlov",
     username:"https://github.com/ru-asdx",
+  },
+  {
+    id:423,
+    fullname:"Parth Khandenath",
+    username:"https://github.com/pa-kh039",
   }
 
 


### PR DESCRIPTION

# Problem
Given the `head` of a linked list, rotate the list to the right by `k` places.


Example 1:
Input: head = [1,2,3,4,5], k = 2
Output: [4,5,1,2,3]

Example 2:
Input: head = [0,1,2], k = 4
Output: [2,0,1]

# Solution

Steps to the algorithm:-

1) Calculate the length of the list.
2) Connect the last node to the first node, converting it to a circular linked list.
3) Iterate to cut the link of the last node and start a node of k%length of the list rotated list.