### PR TITLE
fixed load more contributors button from redirect

### DIFF
--- a/contributors/contributorsList.js
+++ b/contributors/contributorsList.js
@@ -2054,4 +2054,9 @@ contributors = [
     fullname: "Mohit Yadav",
     username: "https://github.com/ymohit1603",
   },
+  {
+    id: 424,
+    fullname: "Barabás Ákos Tamás",
+    username: "https://github.com/Croustys",
+  },
 ];

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
     </div>
     <!-- Please maintain the alignment... -->
     <div class="box mx-auto my-5 justify-content-center" id="box">
-        <a data-aos="zoom-in-down" href="https://hacktoberfest.com/" class="btn btn-outline-secondary btn-lg load-more" id="loadMore"><u>Load More</u></a>
+        <a data-aos="zoom-in-down" class="btn btn-outline-secondary btn-lg load-more" id="loadMore"><u>Load More</u></a>
     </div>
     </div>
     </div>


### PR DESCRIPTION

# Problem
Load more button was redirecting to hacktoberfest website instead of actually loading more contributors.
# Solution
removed the link.

## Changes proposed in this Pull Request :
-  `1.`<!-- transform property added to box-item on hover -->
-  `..`

## Other changes
-
