### PR TITLE
fixed load more bug

### DIFF
--- a/contributors/contributorsList.js
+++ b/contributors/contributorsList.js
@@ -120,6 +120,7 @@ contributors = [
     fullname: "Panchadeep Mazumder",
     username: "https://github.com/panchadeep",
   },
+  
   {
     id: 25,
     fullname: "NITIN JAIN",
@@ -2062,6 +2063,11 @@ contributors = [
   {
     id: 425,
     fullname: "Auro S.",
+    username: "https://github.com/aurocodes",
+  },
+  {
+    id: 426,
+    fullname: "MOHAMMED SALMAN THURAAB",
     username: "https://github.com/aurocodes",
   },
 ];

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
     </div>
     <!-- Please maintain the alignment... -->
     <div class="box mx-auto my-5 justify-content-center" id="box">
-        <a data-aos="zoom-in-down" href="https://hacktoberfest.com/" class="btn btn-outline-secondary btn-lg load-more" id="loadMore"><u>Load More</u></a>
+        <a data-aos="zoom-in-down"  class="btn btn-outline-secondary btn-lg load-more" id="loadMore"><u>Load More</u></a>
     </div>
     </div>
     </div>


### PR DESCRIPTION
# Problem
-[BUG]: #6430 
# Solution
-In the anchor tag of the load more button , it had href link of hacktoberfest . So when ever we are pressing that load more button, the hacktoberfest page with opening

## Changes proposed in this Pull Request :
## Before changes it took the page into hacktoberfest page
<img width="1415" alt="Screenshot 2023-10-14 at 4 13 09 PM" src="https://github.com/fineanmol/Hacktoberfest2023/assets/97426541/4aba4a06-3a94-4d59-b93d-1eeba819dafb">

## After changes the load more button is loading the info of other participants

<img width="1394" alt="Screenshot 2023-10-15 at 12 23 23 PM" src="https://github.com/fineanmol/Hacktoberfest2023/assets/97426541/708e6536-d0e0-41e7-8ec0-0e2d9184a4f5">

