### PR TITLE
update-all-python-packages-at-once using PIP

### DIFF
--- a/Program's_Contributed_By_Contributors/Python_Programs/update-all-python-packages-at-once.py
+++ b/Program's_Contributed_By_Contributors/Python_Programs/update-all-python-packages-at-once.py
@@ -1,0 +1,7 @@
+# update-all-python-packages-at-once USING PIP.py
+
+import pkg_resources
+from subprocess import call
+
+packages = [dist.project_name for dist in pkg_resources.working_set]
+call("pip install --upgrade " + ' '.join(packages), shell=True)


### PR DESCRIPTION
# Problem
- Updating Python Packages one by one using PIP, this is time consuming when we have large number of packages/modules installed.
# Solution
- This program update-all-python-packages-at-once using PIP

## Changes proposed in this Pull Request :
-  `1.`<!-- transform property added to box-item on hover -->
-  `..`

## Other changes
- Added a New program to the Python folder



